### PR TITLE
Removed use of private class, concat::setup. Fixes #15.

### DIFF
--- a/manifests/agentkey.pp
+++ b/manifests/agentkey.pp
@@ -8,7 +8,6 @@ define ossec::agentKey($agent_id,$agent_name, $agent_ip_address, $agent_seed = "
 	$agentKey2 = ossec_md5("$agent_name $agent_ip_address $agent_seed")
 #	$agent_id_str = sprintf("%03d",$agent_id)
 	
-	include concat::setup
 	concat::fragment { "var_ossec_etc_client.keys_${agent_ip_address}_part":
 		target  => "/var/ossec/etc/client.keys",
 		order   => $agentId,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -4,7 +4,6 @@ class ossec::client (
 ) inherits ossec::params {
   include ossec::common
   include ossec::post_install_workarounds
-  include concat::setup
 
   Class['Ossec::Client'] -> Class['Ossec::Post_Install_Workarounds']
 

--- a/manifests/lightclient.pp
+++ b/manifests/lightclient.pp
@@ -1,5 +1,5 @@
 class ossec::lightclient {
-	include concat::setup
+
     @@concat::fragment { "ossec.conf_50_${hostname}" :
                 target => '/var/ossec/etc/ossec.conf',
                 content => template("ossec/50_ossec.conf.erb"),

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,7 +11,6 @@ class ossec::server (
   ) inherits ossec::params {
   include ossec::common
   include ossec::post_install_workarounds
-  include concat::setup
   include mysql
 
   Class['Ossec::Common'] -> Class['Ossec::Server']


### PR DESCRIPTION
There were four files in the OSSEC module that were calling the now private concat::setup class. 
